### PR TITLE
Minor Package Updates

### DIFF
--- a/AsyncNetworkService.xcodeproj/project.pbxproj
+++ b/AsyncNetworkService.xcodeproj/project.pbxproj
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.robotsandpencils.AsyncNetworkService;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -591,7 +591,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.robotsandpencils.AsyncNetworkService;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/AsyncNetworkService.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AsyncNetworkService.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "OHHTTPStubs",
-        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs.git",
-        "state": {
-          "branch": null,
-          "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
-          "version": "9.1.0"
-        }
+  "pins" : [
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/AsyncNetworkService.xcodeproj/xcshareddata/xcschemes/AsyncNetworkService.xcscheme
+++ b/AsyncNetworkService.xcodeproj/xcshareddata/xcschemes/AsyncNetworkService.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E8A9142B279B2D3800095A98"
+               BuildableName = "AsyncNetworkService.framework"
+               BlueprintName = "AsyncNetworkService"
+               ReferencedContainer = "container:AsyncNetworkService.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8A9142B279B2D3800095A98"
+            BuildableName = "AsyncNetworkService.framework"
+            BlueprintName = "AsyncNetworkService"
+            ReferencedContainer = "container:AsyncNetworkService.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Description
After tagging and releasing `0.1.0`,  `Package.resolved` and `AsyncNetworkService.xcscheme` appeared as changes. This PR merges these to main.
- Changes the version to `0.1.1`. 
- Updates Package.resolved
- Adds `AsyncNetworkService.xcscheme`

Post-merge I'll add the tag and release the new version.

## Testing
1. Open the iOSProjectTemplate branch `requestedUpdates` SwiftUI workspace
2. Change the `AsyncHTTPNetworkService` package branch to `feature/mark/minorPkgUpdates`. Verify SPM installs the package with no errors.
3. Run the automated tests. Verify there are no errors.
4. Open `MainView.swift`.
5. Show Previews. Verify the MainView shows with no errors.
6. Declare victory and open 🥃 

