### PR TITLE
makes AsyncNetworkService public, swift linting

### DIFF
--- a/AsyncNetworkService.xcodeproj/xcuserdata/mattkiazyk.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AsyncNetworkService.xcodeproj/xcuserdata/mattkiazyk.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,6 +12,11 @@
 		<key>AsyncNetworkServiceExample.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
+			<integer>2</integer>
+		</dict>
+		<key>AsyncNetworkServiceTests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
 			<integer>1</integer>
 		</dict>
 	</dict>

--- a/AsyncNetworkService/AsyncHTTPNetworkService.swift
+++ b/AsyncNetworkService/AsyncHTTPNetworkService.swift
@@ -7,17 +7,17 @@
 
 import Foundation
 
-/// A service that speaks to a remote resource via URL requests
-protocol AsyncNetworkService: AnyObject {
+/// A  protocol used for `AsyncHTTPNetworkService` that speaks to a remote resource via URL requests
+public protocol AsyncNetworkService: AnyObject {
     var authenticationToken: String { get set }
-    
+
     /// If this is set, all network requests made through this service will have the modifier applied.
     /// To apply multiple mutations to each network request, use `CompositeNetworkRequestModifier`.
     var requestModifiers: [NetworkRequestModifier] { get set }
 
     /// if this is set, all network requests returned with an error will loop through the list.
     var errorHandlers: [AsyncNetworkErrorHandler] { get set }
-    
+
     /// Requests data. This function handles setting up the network request, etc. All subsequent functions build off of this one.
     /// This is the only function that really  needs to  be implemented to provide a new instance of a network service.
     func requestData(_ request: ConvertsToURLRequest, validators: [ResponseValidator]) async throws -> (Data, URLResponse)
@@ -27,25 +27,24 @@ public class AsyncHTTPNetworkService: AsyncNetworkService, BearerTokenAware {
     public var refreshTokenObserver: NotificationObserver?
     public var authenticationToken: String = ""
     public var requestModifiers: [NetworkRequestModifier]
-    
+
     private let urlSession = URLSession(configuration: .ephemeral)
-    
+
     public var errorHandlers: [AsyncNetworkErrorHandler] = []
 
     public init(requestModifiers: [NetworkRequestModifier] = [], errorHandlers: [AsyncNetworkErrorHandler] = []) {
         self.requestModifiers = requestModifiers
         self.errorHandlers = errorHandlers
-        
-        refreshTokenObserver = NotificationObserver( notification: refreshTokenNotification) {
+
+        refreshTokenObserver = NotificationObserver(notification: refreshTokenNotification) {
             [weak self] token in
-            self?.authenticationToken = token
+                self?.authenticationToken = token
         }
     }
-    
+
     private func applyModifiers(to request: ConvertsToURLRequest) -> URLRequest {
-        
         let updatedRequest = requestModifiers.reduce(request.asURLRequest()) { previousRequest, modifier in
-            return modifier.mutate(previousRequest)
+            modifier.mutate(previousRequest)
         }
         // if we've set the authorization header lets update it with the new one that got sent back from the client
         // if not, return the regular request
@@ -55,15 +54,15 @@ public class AsyncHTTPNetworkService: AsyncNetworkService, BearerTokenAware {
             return updatedRequest
         }
     }
-    
+
     func safeRequest<T>(requestBuilder: @escaping () async throws -> T) async throws -> T {
         do {
             return try await requestBuilder()
         } catch {
-            guard let errorHandler = self.errorHandlers.filter({ $0.canHandle(error) }).first else {
+            guard let errorHandler = errorHandlers.filter({ $0.canHandle(error) }).first else {
                 throw error
             }
-            
+
             do {
                 try await errorHandler.handle(error)
                 return try await requestBuilder()
@@ -72,38 +71,37 @@ public class AsyncHTTPNetworkService: AsyncNetworkService, BearerTokenAware {
             }
         }
     }
-    
-    func requestData(_ request: ConvertsToURLRequest, validators: [ResponseValidator]) async throws -> (Data, URLResponse) {
+
+    public func requestData(_ request: ConvertsToURLRequest, validators: [ResponseValidator]) async throws -> (Data, URLResponse) {
         return try await safeRequest {
             let modifiedRequest = self.applyModifiers(to: request)
-            
+
             let dataTask = Task { () -> (Data?, URLResponse) in
-                return try await self.urlSession.data(for: modifiedRequest)
+                try await self.urlSession.data(for: modifiedRequest)
             }
-             
+
             let result = await dataTask.result
-          
+
             switch result {
-            case .failure(let error):
+            case let .failure(error):
                 throw error
-            case .success((let data, let response)):
+            case let .success((data, response)):
                 guard let response = response as? HTTPURLResponse else {
                     throw NetworkError.invalidResponseFormat
                 }
-                
+
                 for validate in validators {
                     do {
                         try validate(response, data)
-                    }
-                    catch {
+                    } catch {
                         throw error
                     }
                 }
-                
+
                 guard let data = data else {
                     throw NetworkError.noDataInResponse
                 }
-                
+
                 return (data, response)
             }
         }
@@ -111,48 +109,43 @@ public class AsyncHTTPNetworkService: AsyncNetworkService, BearerTokenAware {
 }
 
 public extension AsyncHTTPNetworkService {
-    
     /// Requests a single object. That object must conform to `Decodable`. Will interpret the data received as JSON and attempt to decode the object in question from it.
     func requestObject<ObjectType: Decodable>(_ request: ConvertsToURLRequest, validators: [ResponseValidator] = [statusCodeIsIn200s], jsonDecoder: JSONDecoder = JSONDecoder.networkJSONDecoder) async throws -> ObjectType {
-        
         let requestTask = Task { () -> (Data, URLResponse) in
-            return try await requestData(request, validators: validators)
+            try await requestData(request, validators: validators)
         }
-        
+
         let result = await requestTask.result
-        
+
         switch result {
-        case .failure(let error):
+        case let .failure(error):
             throw error
-        
-        case .success((let data, _ )):
+
+        case let .success((data, _)):
             do {
                 return try jsonDecoder.decode(ObjectType.self, from: data)
-            }
-            catch {
+            } catch {
                 throw NetworkError.decoding(error: error)
             }
         }
     }
-    
+
     /// Requests a list of objects. The object in question must conform to `Decodable`. Will interpret the data received as JSON and attempt to decode an array of the object in question from it.
     func requestObjects<ObjectType: Decodable>(_ request: ConvertsToURLRequest, validators: [ResponseValidator] = [statusCodeIsIn200s], jsonDecoder: JSONDecoder = JSONDecoder.networkJSONDecoder) async throws -> [ObjectType] {
-        
         let requestTask = Task { () -> (Data, URLResponse) in
-            return try await requestData(request, validators: validators)
+            try await requestData(request, validators: validators)
         }
-        
+
         let result = await requestTask.result
-        
+
         switch result {
-        case .failure(let error):
+        case let .failure(error):
             throw error
-        
-        case .success((let data, _ )):
+
+        case let .success((data, _)):
             do {
                 return try jsonDecoder.decode([ObjectType].self, from: data)
-            }
-            catch {
+            } catch {
                 throw NetworkError.decoding(error: error)
             }
         }
@@ -160,34 +153,32 @@ public extension AsyncHTTPNetworkService {
 
     /// Requests a string from a network endpoint.
     func requestString(_ request: ConvertsToURLRequest, encoding: String.Encoding = .utf8, validators: [ResponseValidator] = [statusCodeIsIn200s]) async throws -> String {
-        
         let requestTask = Task { () -> (Data, URLResponse) in
-            return try await requestData(request, validators: validators)
+            try await requestData(request, validators: validators)
         }
-        
+
         let result = await requestTask.result
-        
+
         switch result {
-        case .failure(let error):
+        case let .failure(error):
             throw error
-        case .success((let data, _ )):
+        case let .success((data, _)):
             guard let string = String(data: data, encoding: encoding) else {
                 throw NetworkError.decodingString
             }
             return string
         }
     }
-    
 
     /// Requests a network endpoint without any return
     func requestVoid(_ request: ConvertsToURLRequest, validators: [ResponseValidator] = [statusCodeIsIn200s]) async throws {
         let requestTask = Task { () -> (Data, URLResponse) in
-            return try await requestData(request, validators: validators)
+            try await requestData(request, validators: validators)
         }
         let result = await requestTask.result
-        
+
         switch result {
-        case .failure(let error):
+        case let .failure(error):
             throw error
         case .success:
             // can ignore if successful
@@ -198,13 +189,13 @@ public extension AsyncHTTPNetworkService {
     /// Requests a single object. That object must be decodable as a `String`. Will interpret the data received as JSON and attempt to decode the object in question from it.
     func requestStringWithResponse(_ request: ConvertsToURLRequest, encoding: String.Encoding = .utf8, validators: [ResponseValidator] = [statusCodeIsIn200s]) async throws -> (String, URLResponse) {
         let requestTask = Task { () -> (Data, URLResponse) in
-            return try await requestData(request, validators: validators)
+            try await requestData(request, validators: validators)
         }
         let result = await requestTask.result
         switch result {
-        case .failure(let error):
+        case let .failure(error):
             throw error
-        case .success((let data, let response)):
+        case let .success((data, response)):
             guard let string = String(data: data, encoding: encoding) else {
                 throw NetworkError.decodingString
             }

--- a/AsyncNetworkService/Common/NetworkLogger.swift
+++ b/AsyncNetworkService/Common/NetworkLogger.swift
@@ -21,27 +21,27 @@ public protocol NetworkLogger {
 }
 
 class ConsoleLogger: NetworkLogger {
+    static var shared: ConsoleLogger = .init()
 
-   static var shared: ConsoleLogger = ConsoleLogger()
+    func log(_ message: String, type: OSLogType, log: OSLog = .default, sender: String) {
+        let emoji: String
 
-   func log(_ message: String, type: OSLogType, log: OSLog = .default, sender: String) {
-       let emoji: String
- 
-       switch type {
+        switch type {
         case .default: emoji = "➡️"
-           case .debug: emoji = "✳️"
-           case .info: emoji = "✏️"
-           case .fault: emoji = "⚠️"
-           case .error: emoji = "❌"
-       default:
-           emoji = "✳️"
-       }
-       
-       os.os_log(
-           "%@: receive %@",
-           log: log,
-           type: type,
-           emoji,
-           "\(sender): \(message)")
-   }
+        case .debug: emoji = "✳️"
+        case .info: emoji = "✏️"
+        case .fault: emoji = "⚠️"
+        case .error: emoji = "❌"
+        default:
+            emoji = "✳️"
+        }
+
+        os.os_log(
+            "%@: receive %@",
+            log: log,
+            type: type,
+            emoji,
+            "\(sender): \(message)"
+        )
+    }
 }

--- a/AsyncNetworkService/Common/NetworkRequestModifier.swift
+++ b/AsyncNetworkService/Common/NetworkRequestModifier.swift
@@ -21,8 +21,8 @@ public protocol ConvertsToURLRequest {
     func asURLRequest() -> URLRequest
 }
 
-extension NetworkRequestModifier {
-    public func mutate(_ requestModifiable: ConvertsToURLRequest) -> URLRequest {
+public extension NetworkRequestModifier {
+    func mutate(_ requestModifiable: ConvertsToURLRequest) -> URLRequest {
         let urlRequest = requestModifiable.asURLRequest()
         return mutate(urlRequest)
     }

--- a/AsyncNetworkService/Common/NotificationObserver.swift
+++ b/AsyncNetworkService/Common/NotificationObserver.swift
@@ -7,12 +7,11 @@
 
 import Foundation
 
-
 /// A helper generic struct used in Notifications.
 /// A `Notification.name` is a UUID String
 public struct AsyncNotification<T> {
     let name: String = UUID().uuidString
-    
+
     /// A NSNotification.Name type used in Swift notifications
     var notificationName: NSNotification.Name {
         return NSNotification.Name(rawValue: name)
@@ -21,17 +20,17 @@ public struct AsyncNotification<T> {
 
 public class NotificationObserver {
     let observer: NSObjectProtocol
-    
-    init<T>(notification: AsyncNotification<T>, block aBlock: @escaping (T) -> ()) {
+
+    init<T>(notification: AsyncNotification<T>, block aBlock: @escaping (T) -> Void) {
         observer = NotificationCenter.default.addObserver(forName: notification.notificationName, object: nil, queue: nil) { note in
             if let value = (note.userInfo?["value"] as? UserInfoContainer<T>)?.rawValue {
                 aBlock(value)
             } else {
-                assert(false, "Couldn't understand user info")
+                assertionFailure("Couldn't understand user info")
             }
         }
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(observer)
     }
@@ -41,7 +40,7 @@ public class NotificationObserver {
 /// This wraps the userinfo property `value` so it can be used in generics
 class UserInfoContainer<T> {
     let rawValue: T
-    init(_ value: T) { self.rawValue = value }
+    init(_ value: T) { rawValue = value }
 }
 
 func postNotification<T>(notification: AsyncNotification<T>, value: T) {
@@ -54,5 +53,6 @@ protocol BearerTokenAware {
 }
 
 // MARK: - Refresh Token Notification
+
 /// A AsyncNotification type that is used to notify services of when a token has refreshed.
 let refreshTokenNotification: AsyncNotification<String> = AsyncNotification()

--- a/AsyncNetworkService/Common/RequestModifiers/APIKeyRequestModifier.swift
+++ b/AsyncNetworkService/Common/RequestModifiers/APIKeyRequestModifier.swift
@@ -12,7 +12,7 @@ public class APIKeyRequestModifier: NetworkRequestModifier {
     public init(apiKey: String) {
         self.apiKey = apiKey
     }
-    
+
     public func mutate(_ request: URLRequest) -> URLRequest {
         guard
             let url = request.url,
@@ -22,16 +22,16 @@ public class APIKeyRequestModifier: NetworkRequestModifier {
         }
         //
         let apiKey = URLQueryItem(name: "api_key", value: apiKey)
-        
+
         var queryItems: [URLQueryItem] = components.queryItems ?? []
         queryItems.append(apiKey)
         components.queryItems = queryItems
-        
+
         guard let newURL = components.url else {
             assertionFailure("Expected to be able to add a query item to the URL without breaking it")
             return request
         }
-        
+
         var newRequest = request
         newRequest.url = newURL
         return newRequest

--- a/AsyncNetworkService/Common/URLRequestBuilder.swift
+++ b/AsyncNetworkService/Common/URLRequestBuilder.swift
@@ -9,13 +9,13 @@ import Foundation
 
 public enum HTTPMethod: String {
     case options = "OPTIONS"
-    case get     = "GET"
-    case head    = "HEAD"
-    case post    = "POST"
-    case put     = "PUT"
-    case patch   = "PATCH"
-    case delete  = "DELETE"
-    case trace   = "TRACE"
+    case get = "GET"
+    case head = "HEAD"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
+    case trace = "TRACE"
     case connect = "CONNECT"
 }
 
@@ -35,7 +35,7 @@ public enum ContentType: String {
 ///       otherBuilder.get("/some/path?param=blah").withCachePolicy(.returnCacheDataElseLoad)
 public class URLRequestBuilder {
     internal let baseURL: URL
-    
+
     public init(baseURL: URL) {
         self.baseURL = baseURL
     }
@@ -43,87 +43,87 @@ public class URLRequestBuilder {
     public func get(_ requestPath: String, contentType: ContentType = .json) -> URLRequest {
         return URLRequest(url: baseURL).path(requestPath).method(.get).contentType(contentType)
     }
-    
+
     public func post(_ requestPath: String, contentType: ContentType = .json) -> URLRequest {
         return URLRequest(url: baseURL).path(requestPath).method(.post).contentType(contentType)
     }
-    
+
     public func put(_ requestPath: String) -> URLRequest {
         return URLRequest(url: baseURL).path(requestPath).method(.put)
     }
-    
+
     public func delete(_ requestPath: String) -> URLRequest {
         return URLRequest(url: baseURL).path(requestPath).method(.delete)
     }
 }
 
-extension URLRequest {
-    public func path(_ path: String) -> URLRequest {
+public extension URLRequest {
+    func path(_ path: String) -> URLRequest {
         var request = self
         request.url = url?.appendingPathComponent(path)
         return request
     }
-    
-    public func method(_ method: HTTPMethod) -> URLRequest {
+
+    func method(_ method: HTTPMethod) -> URLRequest {
         var request = self
         request.httpMethod = method.rawValue
         return request
     }
-    
-    public func body(json body: Encodable, dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .iso8601) -> URLRequest {
+
+    func body(json body: Encodable, dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .iso8601) -> URLRequest {
         var request = self
         request.httpBody = try? body.serializeToJSON(dateEncodingStrategy: dateEncodingStrategy)
         return request.contentType(.json)
     }
-    
-    public func queryItems(_ items: [String: String]) -> URLRequest {
+
+    func queryItems(_ items: [String: String]) -> URLRequest {
         var request = self
         guard let url = request.url else { return request }
-        
+
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         let urlQueryItems = items.map { key, value in
-            return URLQueryItem(name: key, value: value)
+            URLQueryItem(name: key, value: value)
         }
         components?.append(queryItems: urlQueryItems)
-        
+
         guard let finalURL = components?.url else { return request }
         request.url = finalURL
         return request
     }
-    
-    public func queryItems(_ queryItems: [URLQueryItem]) -> URLRequest {
+
+    func queryItems(_ queryItems: [URLQueryItem]) -> URLRequest {
         var request = self
         guard let url = request.url else { return request }
-        
+
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.append(queryItems: queryItems)
-        
+
         guard let finalURL = components?.url else { return request }
         request.url = finalURL
         return request
     }
-    
-    public func token(_ token: String) -> URLRequest {
+
+    func token(_ token: String) -> URLRequest {
         let bearerRequestModifier = BearerTokenRequestModifier(authenticationToken: token)
         return bearerRequestModifier.mutate(self)
     }
-    
-    public func contentType(_ contentType: ContentType) -> URLRequest {
+
+    func contentType(_ contentType: ContentType) -> URLRequest {
         return setValue(contentType.rawValue, forHeader: "Content-Type")
     }
-    
-    public func setValue(_ value: String, forHeader header: String) -> URLRequest {
+
+    func setValue(_ value: String, forHeader header: String) -> URLRequest {
         var request = self
         request.setValue(value, forHTTPHeaderField: header)
         return request
     }
-    
-    public func withCachePolicy(_ policy: URLRequest.CachePolicy) -> URLRequest {
+
+    func withCachePolicy(_ policy: URLRequest.CachePolicy) -> URLRequest {
         var request = self
         request.cachePolicy = policy
         return request
     }
-    
+
     private func newLine() -> Data {
         return Data("\n".utf8)
     }

--- a/AsyncNetworkService/Extensions/Codable+.swift
+++ b/AsyncNetworkService/Extensions/Codable+.swift
@@ -9,11 +9,11 @@ import Foundation
 extension Encodable {
     /**
      Convert this object to json data
-     
+
      - parameter outputFormatting: The formatting of the output JSON data (compact or pritty printed)
      - parameter dateEncodingStrategy: how do you want to format the date
      - parameter dataEncodingStrategy: what kind of encoding. base64 is the default
-     
+
      - returns: The json data
      */
     func serializeToJSON(
@@ -27,14 +27,14 @@ extension Encodable {
         encoder.dataEncodingStrategy = dataEncodingStrategy
         return try encoder.encode(self)
     }
-    
+
     /**
      Convert this object to a json string
-     
+
      - parameter outputFormatting: The formatting of the output JSON data (compact or pritty printed)
      - parameter dateEncodingStrategy: how do you want to format the date
      - parameter dataEncodingStrategy: what kind of encoding. base64 is the default
-     
+
      - returns: The json string
      */
     func toJSON(
@@ -45,17 +45,18 @@ extension Encodable {
         let data = try serializeToJSON(outputFormatting: outputFormatting, dateEncodingStrategy: dateEncodingStrategy, dataEncodingStrategy: dataEncodingStrategy)
         return String(data: data, encoding: .utf8)
     }
-    
+
     /**
      Save this object to a file in the temp directory
-     
+
      - parameter fileName: The filename
-     
+
      - returns: Nothing
      */
     func saveAsJSONTo(_ fileURL: URL) throws {
         try serializeToJSON().write(to: fileURL, options: .atomic)
     }
+
     /**
      Converts this object to a dictionary
      */
@@ -64,11 +65,10 @@ extension Encodable {
     }
 }
 
-
 extension Decodable {
     /**
      Create an instance of this type from a json string
-     
+
      - parameter data: The json data
      */
     init(jsonData: Data, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601) throws {
@@ -76,16 +76,17 @@ extension Decodable {
         decoder.dateDecodingStrategy = dateDecodingStrategy
         self = try decoder.decode(Self.self, from: jsonData)
     }
-    
+
     /**
      Initialize this object from an archived file from an URL
-     
+
      - parameter fileNameInTemp: The filename
      */
     init(fileURL: URL) throws {
         let data = try Data(contentsOf: fileURL)
         try self.init(jsonData: data)
     }
+
     init(fileURL: URL, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601) throws {
         let data = try Data(contentsOf: fileURL)
         try self.init(jsonData: data, dateDecodingStrategy: dateDecodingStrategy)
@@ -95,22 +96,21 @@ extension Decodable {
 // Generic decoder for dictionarys
 
 extension KeyedDecodingContainer {
-    
-    func decodeAny<T>(_ type: T.Type, forKey key: K) throws -> T {
+    func decodeAny<T>(_: T.Type, forKey key: K) throws -> T {
         guard let value = try decode(AnyCodable.self, forKey: key).value as? T else {
             throw DecodingError.typeMismatch(T.self, DecodingError.Context(codingPath: codingPath, debugDescription: "Decoding of \(T.self) failed"))
         }
         return value
     }
-    
+
     func decodeAnyIfPresent<T>(_ type: T.Type, forKey key: K) throws -> T? {
         if !contains(key) {
             return nil
         }
-        
+
         return try decodeAny(type, forKey: key)
     }
-    
+
     func toDictionary() throws -> [String: Any] {
         var dictionary: [String: Any] = [:]
         for key in allKeys {
@@ -118,50 +118,49 @@ extension KeyedDecodingContainer {
         }
         return dictionary
     }
-    
+
     // codable
     func decode<T>(_ key: KeyedDecodingContainer.Key) throws -> T where T: Decodable {
         return try decode(T.self, forKey: key)
     }
-    
+
     func decodeIfPresent<T>(_ key: KeyedDecodingContainer.Key) throws -> T? where T: Decodable {
         return try decodeIfPresent(T.self, forKey: key)
     }
-    
+
     // any
     func decodeAny<T>(_ key: K) throws -> T {
         return try decodeAny(T.self, forKey: key)
     }
-    
+
     func decodeAnyIfPresent<T>(_ key: K) throws -> T? {
         return try decodeAnyIfPresent(T.self, forKey: key)
     }
-    
+
     // array
     func decodeArray<T: Decodable>(_ key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [T] {
         return try decodeArray([T].self, forKey: key, invalidElementStrategy: invalidElementStrategy)
     }
-    
+
     func decodeArrayIfPresent<T: Decodable>(_ key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [T]? {
         return try decodeArrayIfPresent([T].self, forKey: key, invalidElementStrategy: invalidElementStrategy)
     }
-    
+
     // dictionary
     func decodeDictionary<T: Decodable>(_ key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [String: T] {
         return try decodeDictionary([String: T].self, forKey: key, invalidElementStrategy: invalidElementStrategy)
     }
-    
+
     func decodeDictionaryIfPresent<T: Decodable>(_ key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [String: T]? {
         return try decodeDictionaryIfPresent([String: T].self, forKey: key, invalidElementStrategy: invalidElementStrategy)
     }
 }
 
 extension UnkeyedDecodingContainer {
-    
     mutating func decode<T: Decodable>() throws -> T {
         return try decode(T.self)
     }
-    
+
     mutating func decodeIfPresent<T: Decodable>() throws -> T? {
         return try decodeIfPresent(T.self)
     }
@@ -172,63 +171,62 @@ enum InvalidElementStrategy<T>: CustomStringConvertible {
     case fail
     case fallback(T)
     case custom((DecodingError) -> InvalidElementStrategy<T>)
-    
-    func decodeItem(onError: ((Error) -> ())? = nil, decode: () throws -> T) throws -> T? {
+
+    func decodeItem(onError: ((Error) -> Void)? = nil, decode: () throws -> T) throws -> T? {
         do {
             return try decode()
         } catch {
             onError?(error)
             switch self {
-                case .remove:
-                    return nil
-                case .fail:
-                    throw error
-                case let .fallback(value):
-                    return value
-                case let .custom(getBehaviour):
-                    guard let decodingError = error as? DecodingError else { throw error }
-                    let behaviour = getBehaviour(decodingError)
-                    return try behaviour.decodeItem(onError: onError, decode: decode)
+            case .remove:
+                return nil
+            case .fail:
+                throw error
+            case let .fallback(value):
+                return value
+            case let .custom(getBehaviour):
+                guard let decodingError = error as? DecodingError else { throw error }
+                let behaviour = getBehaviour(decodingError)
+                return try behaviour.decodeItem(onError: onError, decode: decode)
             }
         }
     }
-    
+
     func toType<T>() -> InvalidElementStrategy<T> {
         switch self {
-            case .remove:
-                return .remove
-            case .fail:
+        case .remove:
+            return .remove
+        case .fail:
+            return .fail
+        case let .fallback(value):
+            if let value = value as? T {
+                return .fallback(value)
+            } else {
                 return .fail
-            case let .fallback(value):
-                if let value = value as? T {
-                    return .fallback(value)
-                } else {
-                    return .fail
-                }
-            case let .custom(getBehaviour):
-                return .custom( { error in
-                    getBehaviour(error).toType()
-                })
+            }
+        case let .custom(getBehaviour):
+            return .custom { error in
+                getBehaviour(error).toType()
+            }
         }
     }
-    
+
     public var description: String {
         switch self {
-            case .remove:
-                return "remove"
-            case .fail:
-                return "fail"
-            case .fallback:
-                return "fallback"
-            case .custom:
-                return "custom"
+        case .remove:
+            return "remove"
+        case .fail:
+            return "fail"
+        case .fallback:
+            return "fallback"
+        case .custom:
+            return "custom"
         }
     }
 }
 
 extension KeyedDecodingContainer {
-    
-    func decodeArray<T: Decodable>(_ type: [T].Type, forKey key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [T] {
+    func decodeArray<T: Decodable>(_: [T].Type, forKey key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [T] {
         var container = try nestedUnkeyedContainer(forKey: key)
         var chosenInvalidElementStrategy: InvalidElementStrategy<T>
         if let invalidElementStrategy = invalidElementStrategy {
@@ -238,7 +236,7 @@ extension KeyedDecodingContainer {
         } else {
             chosenInvalidElementStrategy = .fail
         }
-        
+
         var array: [T] = []
         while !container.isAtEnd {
             let element: T? = try chosenInvalidElementStrategy.decodeItem(onError: { _ in
@@ -253,17 +251,17 @@ extension KeyedDecodingContainer {
         }
         return array
     }
-    
+
     func decodeArrayIfPresent<T: Decodable>(_ type: [T].Type, forKey key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [T]? {
         if !contains(key) {
             return nil
         }
         return try decodeArray(type, forKey: key, invalidElementStrategy: invalidElementStrategy)
     }
-    
-    func decodeDictionary<T: Decodable>(_ type: [String: T].Type, forKey key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [String: T] {
-        let container = try self.nestedContainer(keyedBy: RawCodingKey.self, forKey: key)
-        
+
+    func decodeDictionary<T: Decodable>(_: [String: T].Type, forKey key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [String: T] {
+        let container = try nestedContainer(keyedBy: RawCodingKey.self, forKey: key)
+
         var chosenInvalidElementStrategy: InvalidElementStrategy<T>
         if let invalidElementStrategy = invalidElementStrategy {
             chosenInvalidElementStrategy = invalidElementStrategy
@@ -272,10 +270,9 @@ extension KeyedDecodingContainer {
         } else {
             chosenInvalidElementStrategy = .fail
         }
-        
+
         var dictionary: [String: T] = [:]
         for key in container.allKeys {
-            
             let element: T? = try chosenInvalidElementStrategy.decodeItem {
                 try container.decode(T.self, forKey: key)
             }
@@ -285,7 +282,7 @@ extension KeyedDecodingContainer {
         }
         return dictionary
     }
-    
+
     func decodeDictionaryIfPresent<T: Decodable>(_ type: [String: T].Type, forKey key: K, invalidElementStrategy: InvalidElementStrategy<T>? = nil) throws -> [String: T]? {
         if !contains(key) {
             return nil
@@ -301,24 +298,23 @@ extension CodingUserInfoKey {
 // Based on https://github.com/Flight-School/AnyCodable
 /**
  A type-erased `Codable` value.
- 
+
  You can encode or decode mixed-type or unknown values in dictionaries
  and other collections that require `Encodable` or `Decodable` conformance
  by declaring their contained type to be `AnyCodable`.
  */
 struct AnyCodable {
     let value: Any
-    
+
     init<T>(_ value: T?) {
         self.value = value ?? ()
     }
 }
 
 extension AnyCodable: Codable {
-    
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        
+
         if container.decodeNil() {
             self.init(())
         } else if let bool = try? container.decode(Bool.self) {
@@ -339,95 +335,95 @@ extension AnyCodable: Codable {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable value cannot be decoded")
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        
-        switch self.value {
-            case is Void:
-                try container.encodeNil()
-            case let bool as Bool:
-                try container.encode(bool)
-            case let int as Int:
-                try container.encode(int)
-            case let int8 as Int8:
-                try container.encode(int8)
-            case let int16 as Int16:
-                try container.encode(int16)
-            case let int32 as Int32:
-                try container.encode(int32)
-            case let int64 as Int64:
-                try container.encode(int64)
-            case let uint as UInt:
-                try container.encode(uint)
-            case let uint8 as UInt8:
-                try container.encode(uint8)
-            case let uint16 as UInt16:
-                try container.encode(uint16)
-            case let uint32 as UInt32:
-                try container.encode(uint32)
-            case let uint64 as UInt64:
-                try container.encode(uint64)
-            case let float as Float:
-                try container.encode(float)
-            case let double as Double:
-                try container.encode(double)
-            case let string as String:
-                try container.encode(string)
-            case let date as Date:
-                try container.encode(date)
-            case let url as URL:
-                try container.encode(url)
-            case let array as [Any?]:
-                try container.encode(array.map { AnyCodable($0) })
-            case let dictionary as [String: Any?]:
-                try container.encode(dictionary.mapValues { AnyCodable($0) })
-            default:
-                let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyCodable value cannot be encoded")
-                throw EncodingError.invalidValue(self.value, context)
+
+        switch value {
+        case is Void:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let int8 as Int8:
+            try container.encode(int8)
+        case let int16 as Int16:
+            try container.encode(int16)
+        case let int32 as Int32:
+            try container.encode(int32)
+        case let int64 as Int64:
+            try container.encode(int64)
+        case let uint as UInt:
+            try container.encode(uint)
+        case let uint8 as UInt8:
+            try container.encode(uint8)
+        case let uint16 as UInt16:
+            try container.encode(uint16)
+        case let uint32 as UInt32:
+            try container.encode(uint32)
+        case let uint64 as UInt64:
+            try container.encode(uint64)
+        case let float as Float:
+            try container.encode(float)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let date as Date:
+            try container.encode(date)
+        case let url as URL:
+            try container.encode(url)
+        case let array as [Any?]:
+            try container.encode(array.map { AnyCodable($0) })
+        case let dictionary as [String: Any?]:
+            try container.encode(dictionary.mapValues { AnyCodable($0) })
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyCodable value cannot be encoded")
+            throw EncodingError.invalidValue(value, context)
         }
     }
 }
 
 extension AnyCodable: Equatable {
-    static func ==(lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+    static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
         switch (lhs.value, rhs.value) {
-            case is (Void, Void):
-                return true
-            case let (lhs as Bool, rhs as Bool):
-                return lhs == rhs
-            case let (lhs as Int, rhs as Int):
-                return lhs == rhs
-            case let (lhs as Int8, rhs as Int8):
-                return lhs == rhs
-            case let (lhs as Int16, rhs as Int16):
-                return lhs == rhs
-            case let (lhs as Int32, rhs as Int32):
-                return lhs == rhs
-            case let (lhs as Int64, rhs as Int64):
-                return lhs == rhs
-            case let (lhs as UInt, rhs as UInt):
-                return lhs == rhs
-            case let (lhs as UInt8, rhs as UInt8):
-                return lhs == rhs
-            case let (lhs as UInt16, rhs as UInt16):
-                return lhs == rhs
-            case let (lhs as UInt32, rhs as UInt32):
-                return lhs == rhs
-            case let (lhs as UInt64, rhs as UInt64):
-                return lhs == rhs
-            case let (lhs as Float, rhs as Float):
-                return lhs == rhs
-            case let (lhs as Double, rhs as Double):
-                return lhs == rhs
-            case let (lhs as String, rhs as String):
-                return lhs == rhs
-            case (let lhs as [String: AnyCodable], let rhs as [String: AnyCodable]):
-                return lhs == rhs
-            case (let lhs as [AnyCodable], let rhs as [AnyCodable]):
-                return lhs == rhs
-            default:
-                return false
+        case is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyCodable], rhs as [String: AnyCodable]):
+            return lhs == rhs
+        case let (lhs as [AnyCodable], rhs as [AnyCodable]):
+            return lhs == rhs
+        default:
+            return false
         }
     }
 }
@@ -435,12 +431,12 @@ extension AnyCodable: Equatable {
 extension AnyCodable: CustomStringConvertible {
     var description: String {
         switch value {
-            case is Void:
-                return String(describing: nil as Any?)
-            case let value as CustomStringConvertible:
-                return value.description
-            default:
-                return String(describing: value)
+        case is Void:
+            return String(describing: nil as Any?)
+        case let value as CustomStringConvertible:
+            return value.description
+        default:
+            return String(describing: value)
         }
     }
 }
@@ -448,66 +444,64 @@ extension AnyCodable: CustomStringConvertible {
 extension AnyCodable: CustomDebugStringConvertible {
     var debugDescription: String {
         switch value {
-            case let value as CustomDebugStringConvertible:
-                return "AnyCodable(\(value.debugDescription))"
-            default:
-                return "AnyCodable(\(self.description))"
+        case let value as CustomDebugStringConvertible:
+            return "AnyCodable(\(value.debugDescription))"
+        default:
+            return "AnyCodable(\(description))"
         }
     }
 }
 
 extension AnyCodable: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral, ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral, ExpressibleByStringLiteral, ExpressibleByArrayLiteral, ExpressibleByDictionaryLiteral {
-    
-    init(nilLiteral: ()) {
+    init(nilLiteral _: ()) {
         self.init(nil as Any?)
     }
-    
+
     init(booleanLiteral value: Bool) {
         self.init(value)
     }
-    
+
     init(integerLiteral value: Int) {
         self.init(value)
     }
-    
+
     init(floatLiteral value: Double) {
         self.init(value)
     }
-    
+
     init(extendedGraphemeClusterLiteral value: String) {
         self.init(value)
     }
-    
+
     init(stringLiteral value: String) {
         self.init(value)
     }
-    
+
     init(arrayLiteral elements: Any...) {
         self.init(elements)
     }
-    
+
     init(dictionaryLiteral elements: (AnyHashable, Any)...) {
-        self.init(Dictionary<AnyHashable, Any>(elements, uniquingKeysWith: { (first, _) in first }))
+        self.init([AnyHashable: Any](elements, uniquingKeysWith: { first, _ in first }))
     }
 }
 
 struct RawCodingKey: CodingKey {
-    
     private let string: String
     private let int: Int?
-    
+
     var stringValue: String { return string }
-    
+
     init(string: String) {
         self.string = string
         int = nil
     }
-    
+
     init?(stringValue: String) {
         string = stringValue
         int = nil
     }
-    
+
     var intValue: Int? { return int }
     init?(intValue: Int) {
         string = String(describing: intValue)
@@ -516,12 +510,11 @@ struct RawCodingKey: CodingKey {
 }
 
 extension RawCodingKey: ExpressibleByStringLiteral, ExpressibleByIntegerLiteral {
-    
     init(stringLiteral value: String) {
         string = value
         int = nil
     }
-    
+
     init(integerLiteral value: Int) {
         string = ""
         int = value

--- a/AsyncNetworkService/Extensions/JSONDecoder+.swift
+++ b/AsyncNetworkService/Extensions/JSONDecoder+.swift
@@ -7,18 +7,18 @@
 
 import Foundation
 
-extension JSONDecoder {
-    public static let networkJSONDecoder: JSONDecoder = {
+public extension JSONDecoder {
+    static let networkJSONDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601 // does not handle fractional seconds
         return decoder
     }()
-    
+
     // includes three digits of fractional seconds e.g. "2020-05-07T22:30:00.000+00:00"
-    public static let rfc3339WithFractionalSeconds: JSONDecoder = {
+    static let rfc3339WithFractionalSeconds: JSONDecoder = {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(.iso8601)
-        
+
         return decoder
     }()
 }

--- a/AsyncNetworkService/Extensions/URLRequest+.swift
+++ b/AsyncNetworkService/Extensions/URLRequest+.swift
@@ -10,6 +10,7 @@ import Foundation
 var networkRequestObserverStartDateKey: UInt8 = 0
 
 // MARK: - URL Session task did start
+
 let networkTaskDidStartNotification: AsyncNotification<URLSessionDataTask> = AsyncNotification()
 let networkTaskDidCompleteNotification: AsyncNotification<TaskComplete> = AsyncNotification()
 
@@ -46,15 +47,15 @@ public extension URLSession {
             operation: {
                 try await withCheckedThrowingContinuation { continuation in
                     dataTask = self.dataTask(with: request) { data, response, error in
-                        
+
                         guard let task = dataTask else { return }
                         guard let date = objc_getAssociatedObject(task, &networkRequestObserverStartDateKey) as? Date else { return }
                         guard let response = response as? HTTPURLResponse else { return continuation.resume(throwing: NetworkError.noDataInResponse) }
-                        
+
                         let elapsedTime = Date().timeIntervalSince(date)
-                        
+
                         postNotification(notification: networkTaskDidCompleteNotification, value: TaskComplete(response: response, elapsedTime: elapsedTime))
-                        
+
                         guard let data = data else {
                             let error = error ?? URLError(.badServerResponse)
                             return continuation.resume(throwing: error)
@@ -64,7 +65,7 @@ public extension URLSession {
                     }
 
                     dataTask?.resume()
-                    
+
                     // Posts a notification to time a task
                     guard let task = dataTask else { return }
                     postNotification(notification: networkTaskDidStartNotification, value: task)

--- a/AsyncNetworkService/NetworkError.swift
+++ b/AsyncNetworkService/NetworkError.swift
@@ -15,8 +15,8 @@ public enum NetworkError: Error, Equatable {
     case noDataInResponse
 }
 
-extension Equatable where Self : Error {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
+public extension Equatable where Self: Error {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         lhs as Error == rhs as Error
     }
 }

--- a/AsyncNetworkServiceExample/APIKeyRequestModifier.swift
+++ b/AsyncNetworkServiceExample/APIKeyRequestModifier.swift
@@ -7,5 +7,4 @@
 
 import Foundation
 
-
 // example of passing up a `NetworkRequestModifier` to always add in

--- a/AsyncNetworkServiceExample/AsyncNetworkServiceExampleApp.swift
+++ b/AsyncNetworkServiceExample/AsyncNetworkServiceExampleApp.swift
@@ -5,8 +5,8 @@
 //  Created by Matt Kiazyk on 2022-01-21.
 //
 
-import SwiftUI
 import AsyncNetworkService
+import SwiftUI
 
 @main
 struct AsyncNetworkServiceExampleApp: App {

--- a/AsyncNetworkServiceExample/AsyncService.swift
+++ b/AsyncNetworkServiceExample/AsyncService.swift
@@ -5,55 +5,49 @@
 //  Created by Matt Kiazyk on 2022-01-21.
 //
 
-import Foundation
 import AsyncNetworkService
+import Foundation
 
 // Example of using a Rest API
 
 class GiphyService {
-    
     let routes: Routes
     var networkService: AsyncHTTPNetworkService
-    
+
     struct Routes {
-        var baseRequestBuilder: URLRequestBuilder { return URLRequestBuilder(baseURL:  URL(string: "https://api.giphy.com/v1")!) }
-        
+        var baseRequestBuilder: URLRequestBuilder { return URLRequestBuilder(baseURL: URL(string: "https://api.giphy.com/v1")!) }
+
         func getRandomGif() -> URLRequest {
             return baseRequestBuilder.get("gifs/random")
         }
     }
-    
+
     init() {
-        self.routes = Routes()
-        
-        self.networkService = AsyncHTTPNetworkService(requestModifiers: [APIKeyRequestModifier(apiKey: "FitddX5BlIIpURiBMZJRmSDDV8MBEgBf")])
+        routes = Routes()
+
+        networkService = AsyncHTTPNetworkService(requestModifiers: [APIKeyRequestModifier(apiKey: "FitddX5BlIIpURiBMZJRmSDDV8MBEgBf")])
     }
-    
+
     /// Example api call to return a random gif url
     func getRandomGif(tag: String, rating: String = "g") async throws -> URL {
-    
         let urlRequest = routes.getRandomGif().queryItems([
             "tag": tag,
-            "rating": rating
+            "rating": rating,
         ])
-        
+
         let requestTask = Task { () -> GiphyDataWrapper in
-            return try await networkService.requestObject(urlRequest)
+            try await networkService.requestObject(urlRequest)
         }
-        
+
         let result = await requestTask.result
-        
+
         switch result {
-        case .failure(let error):
+        case let .failure(error):
             print("ERROR LOADING GIF: \(error.localizedDescription)")
             throw error
-            
-        case .success(let giphy):
+
+        case let .success(giphy):
             return URL(string: giphy.data.images.downsizedLarge.url)!
         }
-        
     }
-    
 }
-
-

--- a/AsyncNetworkServiceExample/ContentView.swift
+++ b/AsyncNetworkServiceExample/ContentView.swift
@@ -9,16 +9,16 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject var viewModel = GiphyViewModel(service: GiphyService())
-    
+
     var body: some View {
         VStack {
             AsyncImage(url: viewModel.url) { phase in
                 switch phase {
                 case .empty:
                     ProgressView()
-                case .success(let image):
+                case let .success(image):
                     image.resizable()
-                         .aspectRatio(contentMode: .fit)
+                        .aspectRatio(contentMode: .fit)
                 case .failure:
                     Image(systemName: "photo")
                 @unknown default:
@@ -36,34 +36,31 @@ struct ContentView: View {
                     .padding(20)
             }
             .contentShape(Rectangle())
-         
         }
         .onAppear {
             viewModel.fetchGif()
         }
     }
-    
 }
 
 @MainActor
 class GiphyViewModel: ObservableObject {
     @Published var url: URL?
- 
+
     var asyncService: GiphyService
-    
+
     init(service: GiphyService) {
-        self.asyncService = service
+        asyncService = service
     }
-    
+
     nonisolated func fetchGif() {
         Task {
             let fetchedURL = try await asyncService.getRandomGif(tag: "blow kiss")
             await updateURL(fetchedURL)
         }
     }
-    
+
     func updateURL(_ url: URL?) async {
         self.url = url
     }
 }
-

--- a/AsyncNetworkServiceExample/GiphyData.swift
+++ b/AsyncNetworkServiceExample/GiphyData.swift
@@ -17,8 +17,7 @@ struct GiphyData: Decodable {
 
 struct GiphyImages: Decodable {
     let downsizedLarge: GiphyImageData
-    
-    
+
     enum CodingKeys: String, CodingKey {
         case downsizedLarge = "downsized_large"
     }

--- a/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
+++ b/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
@@ -5,13 +5,12 @@
 //  Created by Matt Kiazyk on 2022-01-21.
 //
 
-import XCTest
 import OHHTTPStubs
+import XCTest
 
 @testable import AsyncNetworkService
 
 class AsyncNetworkServiceTests: XCTestCase {
-
     struct TestContext {
         let subject: AsyncHTTPNetworkService
         let mockModifiers: [NetworkRequestModifierMock]!
@@ -25,7 +24,6 @@ class AsyncNetworkServiceTests: XCTestCase {
         }
     }
 
-    
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
@@ -36,21 +34,22 @@ class AsyncNetworkServiceTests: XCTestCase {
     }
 
     // MARK: RequestData
+
     func testRequestDataSuccessfully() async throws {
         let testContext = TestContext()
-        
+
         stubValidData()
-        
+
         // it downloads some data
         let result = try await testContext.subject.requestData(URL.stub(), validators: [passingValidatorMock])
         XCTAssertNotNil(result.0)
-        
+
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
             XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestValidatorFailsAndItsTheOnlyOne() async throws {
         let testContext = TestContext()
         stubValidData()
@@ -62,31 +61,31 @@ class AsyncNetworkServiceTests: XCTestCase {
             // reports the error that the validator encountered"
             XCTAssertEqual(error as? NetworkError, NetworkError.noDataInResponse)
         }
-        
+
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
             XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestValidatorFailsAndThereAreAlsoPassingValidators() async throws {
         let testContext = TestContext()
         stubValidData()
-        
+
         // it downloads some data
         do {
             _ = try await testContext.subject.requestData(URL.stub(), validators: [
                 passingValidatorMock,
                 passingValidatorMock,
                 failingValidatorMock(error: NetworkError.noDataInResponse),
-                passingValidatorMock
+                passingValidatorMock,
             ])
             throw "I shouldn't call this"
         } catch {
             // reports the error that the validator encountered"
             XCTAssertEqual(error as? NetworkError, NetworkError.noDataInResponse)
         }
-        
+
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
             XCTAssertEqual(mockModifier.mutateCallCount, 1)
@@ -94,32 +93,32 @@ class AsyncNetworkServiceTests: XCTestCase {
     }
 
     // MARK: RequestObject
-    
+
     func testRequestObjectWithValidJSON() async throws {
         let testContext = TestContext()
         stubValidJSON(CodableMock.validJSON)
 
         // it downloads some data
         do {
-           let result: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
-           XCTAssertNotNil(result)
+            let result: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
+            XCTAssertNotNil(result)
         } catch {
-           throw "I shouldn't call this"
+            throw "I shouldn't call this"
         }
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectWithWrongKeys() async throws {
         let testContext = TestContext()
         stubValidJSON(CodableMock.jsonWithWrongKeys)
 
         // it reports an error
         do {
-            let _ : CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
+            let _: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -130,17 +129,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectWrongValueType() async throws {
         let testContext = TestContext()
         stubValidJSON(CodableMock.jsonWithWrongTypes)
 
         // it reports an error
         do {
-            let _ : CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
+            let _: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -151,17 +150,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectValildJSONArray() async throws {
         let testContext = TestContext()
         stubValidJSON([CodableMock.validJSON])
 
         // it reports an error
         do {
-            let _ : CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
+            let _: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -172,17 +171,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectWithInvalidJSON() async throws {
         let testContext = TestContext()
         stubInvalidJSON()
 
         // it reports an error
         do {
-            let _ : CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
+            let _: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -193,17 +192,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectWhenErrorEncountered() async throws {
         let testContext = TestContext()
         stubError()
 
         // it reports an error
         do {
-            let _ : CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
+            let _: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -214,17 +213,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectWhenRequestValidatorFailsOne() async throws {
         let testContext = TestContext()
         stubValidJSON(CodableMock.validJSON)
 
         // it reports an error
         do {
-            let _ : CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [failingValidatorMock(error: NetworkError.noDataInResponse)])
+            let _: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [failingValidatorMock(error: NetworkError.noDataInResponse)])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -235,21 +234,21 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectWhenRequestValidatorFailsAndPasses() async throws {
         let testContext = TestContext()
         stubValidJSON(CodableMock.validJSON)
 
         // it reports an error
         do {
-            let _ : CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [
+            let _: CodableMock = try await testContext.subject.requestObject(URL.stub(), validators: [
                 passingValidatorMock,
                 passingValidatorMock,
                 failingValidatorMock(error: NetworkError.noDataInResponse),
-                passingValidatorMock
+                passingValidatorMock,
             ])
             throw "I shouldn't call this"
         } catch {
@@ -261,37 +260,37 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     // MARK: RequestObjects
-    
+
     func testRequestObjectsWithValidJSON() async throws {
         let testContext = TestContext()
         stubValidJSON([CodableMock.validJSON])
 
         // it downloads some data
         do {
-           let result: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
-           XCTAssertNotNil(result)
+            let result: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
+            XCTAssertNotNil(result)
         } catch {
-           throw "I shouldn't call this"
+            throw "I shouldn't call this"
         }
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectsWithValidNonArray() async throws {
         let testContext = TestContext()
         stubValidJSON(CodableMock.validJSON)
 
         // it reports an error
         do {
-            let _ : [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
+            let _: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -302,17 +301,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectsWithWrongKeys() async throws {
         let testContext = TestContext()
         stubValidJSON([CodableMock.jsonWithWrongKeys])
 
         // it reports an error
         do {
-            let _ : [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
+            let _: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -323,17 +322,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectsWrongValueType() async throws {
         let testContext = TestContext()
         stubValidJSON([CodableMock.jsonWithWrongTypes])
 
         // it reports an error
         do {
-            let _ : [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
+            let _: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -344,17 +343,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectsWithInvalidJSON() async throws {
         let testContext = TestContext()
         stubInvalidJSON()
 
         // it reports an error
         do {
-            let _ : [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
+            let _: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -365,17 +364,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectsWhenErrorEncountered() async throws {
         let testContext = TestContext()
         stubError()
 
         // it reports an error
         do {
-            let _ : [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
+            let _: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -386,17 +385,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectsWhenRequestValidatorFailsOne() async throws {
         let testContext = TestContext()
         stubValidJSON([CodableMock.validJSON])
 
         // it reports an error
         do {
-            let _ : [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [failingValidatorMock(error: NetworkError.noDataInResponse)])
+            let _: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [failingValidatorMock(error: NetworkError.noDataInResponse)])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -407,21 +406,21 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestObjectsWhenRequestValidatorFailsAndPasses() async throws {
         let testContext = TestContext()
         stubValidJSON([CodableMock.validJSON])
 
         // it reports an error
         do {
-            let _ : [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [
+            let _: [CodableMock] = try await testContext.subject.requestObjects(URL.stub(), validators: [
                 passingValidatorMock,
                 passingValidatorMock,
                 failingValidatorMock(error: NetworkError.noDataInResponse),
-                passingValidatorMock
+                passingValidatorMock,
             ])
             throw "I shouldn't call this"
         } catch {
@@ -433,34 +432,34 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     // MARK: requestString
+
     func testRequestStringWithValidJSON() async throws {
         let testContext = TestContext()
         stubString("Bobs your uncle")
 
         // it downloads some data
         do {
-           let result: String = try await testContext.subject.requestString(URL.stub(), validators: [])
-           XCTAssertEqual(result, "Bobs your uncle")
+            let result: String = try await testContext.subject.requestString(URL.stub(), validators: [])
+            XCTAssertEqual(result, "Bobs your uncle")
         } catch {
-           throw "I shouldn't call this"
+            throw "I shouldn't call this"
         }
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestStringWithNonString() async throws {
         let testContext = TestContext()
         stubValidData(data: UIImage.stub().pngData()!)
 
-        
         do {
             let _: String = try await testContext.subject.requestString(URL.stub(), validators: [])
             throw "I shouldn't call this"
@@ -473,10 +472,10 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestStringWithError() async throws {
         let testContext = TestContext()
         stubError(NetworkError.noDataInResponse)
@@ -493,17 +492,17 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestStringWhenRequestValidatorFailsOne() async throws {
         let testContext = TestContext()
         stubString("Hola")
 
         // it reports an error
         do {
-            let _ : String = try await testContext.subject.requestString(URL.stub(), validators: [failingValidatorMock(error: NetworkError.noDataInResponse)])
+            let _: String = try await testContext.subject.requestString(URL.stub(), validators: [failingValidatorMock(error: NetworkError.noDataInResponse)])
             throw "I shouldn't call this"
         } catch {
             let networkError = error as? NetworkError
@@ -514,21 +513,21 @@ class AsyncNetworkServiceTests: XCTestCase {
 
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
+
     func testRequestStringWhenRequestValidatorFailsAndPasses() async throws {
         let testContext = TestContext()
         stubString("Hola")
 
         // it reports an error
         do {
-            let _ : String = try await testContext.subject.requestString(URL.stub(), validators: [
+            let _: String = try await testContext.subject.requestString(URL.stub(), validators: [
                 passingValidatorMock,
                 passingValidatorMock,
                 failingValidatorMock(error: NetworkError.noDataInResponse),
-                passingValidatorMock
+                passingValidatorMock,
             ])
             throw "I shouldn't call this"
         } catch {
@@ -537,11 +536,10 @@ class AsyncNetworkServiceTests: XCTestCase {
                 throw "Error is not a noDataInResponse"
             }
         }
-
+        runAsyncTest {}
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
-           XCTAssertEqual(mockModifier.mutateCallCount, 1)
+            XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
     }
-    
 }

--- a/AsyncNetworkServiceTests/TestHelpers/Mocks.swift
+++ b/AsyncNetworkServiceTests/TestHelpers/Mocks.swift
@@ -1,14 +1,14 @@
-import Foundation
 @testable import AsyncNetworkService
+import Foundation
 
 typealias JSONDictionary = [String: Any]
 typealias JSONArray = [JSONDictionary]
 
 final class NetworkRequestModifierMock: NetworkRequestModifier {
-    
     public init() {}
-    
+
     // MARK: - mutate
+
     public var mutateCallCount = 0
     public var mutateReceivedRequest: URLRequest?
     public var mutateReturnValue: URLRequest!
@@ -18,22 +18,23 @@ final class NetworkRequestModifierMock: NetworkRequestModifier {
         return mutateReturnValue
     }
 }
+
 extension String: Error {}
 
-let passingValidatorMock: ResponseValidator = { response, data in
+let passingValidatorMock: ResponseValidator = { _, _ in
     // throw no error
 }
 
 func failingValidatorMock(error: Error = NetworkError.invalidResponseFormat) -> ResponseValidator {
-    return { response, data in
+    return { _, _ in
         throw error
     }
 }
 
 struct CodableMock: Codable {
     var someValue: String
-        
-    static let validJSON: JSONDictionary = [ "someValue": "la la" ]
-    static let jsonWithWrongKeys: JSONDictionary = [ "wrongKey": "la la" ]
-    static let jsonWithWrongTypes: JSONDictionary = [ "wrongKey": 2 ]
+
+    static let validJSON: JSONDictionary = ["someValue": "la la"]
+    static let jsonWithWrongKeys: JSONDictionary = ["wrongKey": "la la"]
+    static let jsonWithWrongTypes: JSONDictionary = ["wrongKey": 2]
 }

--- a/AsyncNetworkServiceTests/TestHelpers/OHHTTPHelper.swift
+++ b/AsyncNetworkServiceTests/TestHelpers/OHHTTPHelper.swift
@@ -1,15 +1,15 @@
 
+import AsyncNetworkService
 import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
-import AsyncNetworkService
 
 // convenience helpers for stubbing data
-let everything: (URLRequest) -> (Bool) = { _ in return true }
+let everything: (URLRequest) -> (Bool) = { _ in true }
 let timeout: DispatchTimeInterval = .seconds(2)
 
 func testWithStub(response: HTTPStubsResponse, test: @escaping (@escaping () -> Void) -> Void) {
-    stub(condition: everything) { _ in return response }
+    stub(condition: everything) { _ in response }
     test {
         HTTPStubs.removeAllStubs()
     }
@@ -19,12 +19,11 @@ func stubValidData(data: Data = Data(), statusCode: Int32 = 200, test: @escaping
     testWithStub(response: HTTPStubsResponse(data: data, statusCode: statusCode, headers: nil), test: test)
 }
 
-
 func stubValidData(data: Data = Data(), response: HTTPStubsResponse? = nil) {
     if let response = response {
-        stub(condition: everything) { _ in return response }
+        stub(condition: everything) { _ in response }
     } else {
-        stub(condition: everything) { _ in return HTTPStubsResponse(data: data, statusCode: 200, headers: nil) }
+        stub(condition: everything) { _ in HTTPStubsResponse(data: data, statusCode: 200, headers: nil) }
     }
 }
 

--- a/AsyncNetworkServiceTests/TestHelpers/Stubs.swift
+++ b/AsyncNetworkServiceTests/TestHelpers/Stubs.swift
@@ -20,13 +20,13 @@ extension UIImage {
         let imageSize = CGSize(width: 5, height: 5)
         UIGraphicsBeginImageContextWithOptions(imageSize, false, 1)
         let context = UIGraphicsGetCurrentContext()!
-        
+
         let rectangle = CGRect(x: 0, y: 0, width: imageSize.width, height: imageSize.height)
-        
+
         context.setFillColor(UIColor.red.cgColor)
         context.addRect(rectangle)
         context.drawPath(using: .fill)
-        
+
         let newImage = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
         return newImage

--- a/Package.swift
+++ b/Package.swift
@@ -5,16 +5,16 @@ let package = Package(
     name: "AsyncNetworkService",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15)
+        .macOS(.v10_15),
     ],
     products: [
         .library(
             name: "AsyncNetworkService",
             targets: ["AsyncNetworkService"]
-        )
+        ),
     ],
     dependencies: [
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.0.0")
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.0.0"),
     ],
     targets: [
         .target(
@@ -26,6 +26,6 @@ let package = Package(
             name: "AsyncNetworkServiceTests",
             dependencies: ["OHHTTPStubs"],
             path: "./AsyncNetworkServiceTests"
-        )
+        ),
     ]
 )


### PR DESCRIPTION
Updates the main `AsyncNetworkService` protocol to be public, so that users can mock easier the network calls. 

