### PR TITLE
Add response interceptors

### DIFF
--- a/AsyncNetworkService.xcodeproj/project.pbxproj
+++ b/AsyncNetworkService.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4AB0D5032876099B00C36A3A /* NetworkResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */; };
 		E8A91431279B2D3800095A98 /* AsyncNetworkService.docc in Sources */ = {isa = PBXBuildFile; fileRef = E8A91430279B2D3800095A98 /* AsyncNetworkService.docc */; };
 		E8A91437279B2D3800095A98 /* AsyncNetworkService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */; };
 		E8A9143C279B2D3800095A98 /* AsyncNetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A9143B279B2D3800095A98 /* AsyncNetworkServiceTests.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResponseInterceptor.swift; sourceTree = "<group>"; };
 		8347924927FCBCC100AFDDF3 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncNetworkService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8A9142F279B2D3800095A98 /* AsyncNetworkService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncNetworkService.h; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 				E8A91456279B33F500095A98 /* NotificationObserver.swift */,
 				E8A91458279B353200095A98 /* URLRequestBuilder.swift */,
 				E8A9147E279B677600095A98 /* NetworkLogger.swift */,
+				4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E8A9144E279B309900095A98 /* URL+.swift in Sources */,
+				4AB0D5032876099B00C36A3A /* NetworkResponseInterceptor.swift in Sources */,
 				E8A91459279B353200095A98 /* URLRequestBuilder.swift in Sources */,
 				E8A9145D279B386800095A98 /* Codable+.swift in Sources */,
 				E8A91449279B301800095A98 /* NetworkRequestModifier.swift in Sources */,

--- a/AsyncNetworkService/AsyncHTTPNetworkService.swift
+++ b/AsyncNetworkService/AsyncHTTPNetworkService.swift
@@ -19,7 +19,7 @@ public protocol AsyncNetworkService: AnyObject {
     var errorHandlers: [AsyncNetworkErrorHandler] { get set }
     
     /// if this is set, all network reponses returned with success will call `handle` on these interceptors
-    var reponseInterceptors: [NetworkResponseInterceptor] { get set }
+    var responseInterceptors: [NetworkResponseInterceptor] { get set }
 
     /// Requests data. This function handles setting up the network request, etc. All subsequent functions build off of this one.
     /// This is the only function that really  needs to  be implemented to provide a new instance of a network service.
@@ -30,7 +30,7 @@ public class AsyncHTTPNetworkService: AsyncNetworkService, BearerTokenAware {
     public var refreshTokenObserver: NotificationObserver?
     public var authenticationToken: String = ""
     public var requestModifiers: [NetworkRequestModifier]
-    public var reponseInterceptors: [NetworkResponseInterceptor]
+    public var responseInterceptors: [NetworkResponseInterceptor]
 
     private let urlSession = URLSession(configuration: .ephemeral)
 
@@ -43,7 +43,7 @@ public class AsyncHTTPNetworkService: AsyncNetworkService, BearerTokenAware {
     ) {
         self.requestModifiers = requestModifiers
         self.errorHandlers = errorHandlers
-        self.reponseInterceptors = reponseInterceptors
+        self.responseInterceptors = reponseInterceptors
 
         refreshTokenObserver = NotificationObserver(notification: refreshTokenNotification) {
             [weak self] token in
@@ -111,7 +111,7 @@ public class AsyncHTTPNetworkService: AsyncNetworkService, BearerTokenAware {
                     throw NetworkError.noDataInResponse
                 }
                 
-                guard let responseInterceptor = self.reponseInterceptors.filter({ $0.shouldHandle(data: data, response: response, request: request) }).first else {
+                guard let responseInterceptor = self.responseInterceptors.filter({ $0.shouldHandle(data: data, response: response, request: request) }).first else {
                     return (data, response)
                 }
                 

--- a/AsyncNetworkService/Common/NetworkResponseInterceptor.swift
+++ b/AsyncNetworkService/Common/NetworkResponseInterceptor.swift
@@ -1,0 +1,18 @@
+//
+//  NetworkResponseInterceptor.swift
+//  AsyncNetworkService
+//
+//  Created by Alex Maslov on 2022-07-06.
+//
+
+import Foundation
+
+public protocol NetworkResponseInterceptor {
+    
+    /// Returns true of this interceptor should handle the response
+    func shouldHandle(data: Data, response: URLResponse, request: ConvertsToURLRequest) -> Bool
+    
+    /// Intercepts response and allows interceptor to modify response data before being passed back to original caller.
+    /// Should return original response data if no modifications are necessary
+    func handle(data: Data, response: URLResponse, request: ConvertsToURLRequest) -> (Data, URLResponse)
+}

--- a/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
+++ b/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
@@ -560,7 +560,7 @@ class AsyncNetworkServiceTests: XCTestCase {
     
     func testmodifyingInterceptor() async throws {
         let testContext = TestContext()
-        testContext.subject.reponseInterceptors = [
+        testContext.subject.responseInterceptors = [
             testContext.inactiveInterceptor,
             testContext.modifyingInterceptor
         ]
@@ -586,7 +586,7 @@ class AsyncNetworkServiceTests: XCTestCase {
     
     func testPassthroughInterceptor() async throws {
         let testContext = TestContext()
-        testContext.subject.reponseInterceptors = [
+        testContext.subject.responseInterceptors = [
             testContext.inactiveInterceptor
         ]
         

--- a/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
+++ b/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
@@ -14,13 +14,28 @@ class AsyncNetworkServiceTests: XCTestCase {
     struct TestContext {
         let subject: AsyncHTTPNetworkService
         let mockModifiers: [NetworkRequestModifierMock]!
+        let inactiveInterceptor: NetworkReponseInterceptorMock = {
+            let mock = NetworkReponseInterceptorMock()
+            mock.shouldHandleReturnValue = false
+            return mock
+        }()
+        let modifyingInterceptor: NetworkReponseInterceptorMock = {
+            let mock = NetworkReponseInterceptorMock()
+            mock.shouldHandleReturnValue = true
+            mock.handleReturnValue = (Data.modifiedStub, URLResponse.modifiedStub)
+            return mock
+        }()
 
         init() {
             mockModifiers = [NetworkRequestModifierMock(), NetworkRequestModifierMock()]
             mockModifiers.forEach { mockModifier in
                 mockModifier.mutateReturnValue = .stub()
             }
-            subject = AsyncHTTPNetworkService(requestModifiers: mockModifiers)
+            
+            subject = AsyncHTTPNetworkService(
+                requestModifiers: mockModifiers,
+                reponseInterceptors: []
+            )
         }
     }
 
@@ -536,10 +551,57 @@ class AsyncNetworkServiceTests: XCTestCase {
                 throw "Error is not a noDataInResponse"
             }
         }
-        runAsyncTest {}
+        // runAsyncTest {}
         // it applies modifications
         testContext.mockModifiers.forEach { mockModifier in
             XCTAssertEqual(mockModifier.mutateCallCount, 1)
         }
+    }
+    
+    func testmodifyingInterceptor() async throws {
+        let testContext = TestContext()
+        testContext.subject.reponseInterceptors = [
+            testContext.inactiveInterceptor,
+            testContext.modifyingInterceptor
+        ]
+        
+        let originalDataToReturn = Data.originalStub
+        
+        stubValidData(data: originalDataToReturn, response: nil)
+
+        // it downloads some data
+        let result = try await testContext.subject.requestData(URL.stub(), validators: [passingValidatorMock])
+
+        // it calls applicable interceptor
+        XCTAssertEqual(testContext.inactiveInterceptor.handleCallCount, 0)
+        XCTAssertEqual(testContext.modifyingInterceptor.handleCallCount, 1)
+        
+        // modifying interceptor receives original data
+        XCTAssertEqual(originalDataToReturn, testContext.modifyingInterceptor.handleReceivedValue?.data)
+        
+        // interceptor modifies the response
+        XCTAssertEqual(result.0, testContext.modifyingInterceptor.handleReturnValue?.data)
+        XCTAssertEqual(String(decoding: result.0, as: UTF8.self), String.modified)
+    }
+    
+    func testPassthroughInterceptor() async throws {
+        let testContext = TestContext()
+        testContext.subject.reponseInterceptors = [
+            testContext.inactiveInterceptor
+        ]
+        
+        let originalDataToReturn = Data.originalStub
+        
+        stubValidData(data: originalDataToReturn, response: nil)
+
+        // it downloads some data
+        let result = try await testContext.subject.requestData(URL.stub(), validators: [passingValidatorMock])
+
+        // no interceptors called
+        XCTAssertEqual(testContext.inactiveInterceptor.handleCallCount, 0)
+        
+        // original data returned
+        XCTAssertEqual(result.0, originalDataToReturn)
+        XCTAssertEqual(String(decoding: result.0, as: UTF8.self), String.original)
     }
 }

--- a/AsyncNetworkServiceTests/TestHelpers/Mocks.swift
+++ b/AsyncNetworkServiceTests/TestHelpers/Mocks.swift
@@ -19,6 +19,28 @@ final class NetworkRequestModifierMock: NetworkRequestModifier {
     }
 }
 
+final class NetworkReponseInterceptorMock: NetworkResponseInterceptor {
+    
+    public var shouldHandleCallCount = 0
+    public var shouldHandleReceivedValue: (data: Data, response: URLResponse, request: ConvertsToURLRequest)?
+    public var shouldHandleReturnValue: Bool!
+    public func shouldHandle(data: Data, response: URLResponse, request: ConvertsToURLRequest) -> Bool {
+        shouldHandleCallCount += 1
+        shouldHandleReceivedValue = (data, response, request)
+        return shouldHandleReturnValue
+    }
+    
+    public var handleCallCount = 0
+    public var handleReceivedValue: (data: Data, response: URLResponse, request: ConvertsToURLRequest)?
+    public var handleReturnValue: (data: Data, response: URLResponse)?
+    public func handle(data: Data, response: URLResponse, request: ConvertsToURLRequest) -> (Data, URLResponse) {
+        handleCallCount += 1
+        handleReceivedValue = (data, response, request)
+        return handleReturnValue ?? (data, response)
+    }
+    
+}
+
 extension String: Error {}
 
 let passingValidatorMock: ResponseValidator = { _, _ in

--- a/AsyncNetworkServiceTests/TestHelpers/Stubs.swift
+++ b/AsyncNetworkServiceTests/TestHelpers/Stubs.swift
@@ -13,6 +13,10 @@ extension URL {
     static func stub() -> URL {
         return URL(string: "http://www.google.com")!
     }
+    
+    static func modifiedStub() -> URL {
+        return URL(string: "http://www.google.com/modified")!
+    }
 }
 
 extension UIImage {
@@ -30,5 +34,30 @@ extension UIImage {
         let newImage = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
         return newImage
+    }
+}
+
+extension String {
+    static var original: String = "original"
+    static var modified: String = "modified"
+}
+
+extension URLResponse {
+    static var originalStub: URLResponse {
+        URLResponse(url: .stub(), mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+    }
+    
+    static var modifiedStub: URLResponse {
+        URLResponse(url: .modifiedStub(), mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+    }
+}
+
+extension Data {
+    static var originalStub: Data {
+        String.original.data(using: .utf8)!
+    }
+    
+    static var modifiedStub: Data {
+        String.modified.data(using: .utf8)!
     }
 }


### PR DESCRIPTION
The original idea comes from [Apollo Interceptors](https://www.apollographql.com/docs/ios/request-pipeline/) where the network service allows external introspection of request before the are handed over to the original caller. This allows the calling framework to centrally react to all responses which may contain the same data values within multiple endpoints (e.g access token structures attached to various types of response models). The idea is the interceptor would observe the response data and request that was originally made and then decide weather it contains a central data item that needs or even if the response needs to be modified to enforce a lack congruity on the back-end. 