### PR TITLE
Add token provider

### DIFF
--- a/AsyncNetworkService.xcodeproj/project.pbxproj
+++ b/AsyncNetworkService.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4AB0D5032876099B00C36A3A /* NetworkResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */; };
+		4AB0D50728763C0E00C36A3A /* AuthenticationTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0D50628763C0E00C36A3A /* AuthenticationTokenProvider.swift */; };
 		E8A91431279B2D3800095A98 /* AsyncNetworkService.docc in Sources */ = {isa = PBXBuildFile; fileRef = E8A91430279B2D3800095A98 /* AsyncNetworkService.docc */; };
 		E8A91437279B2D3800095A98 /* AsyncNetworkService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */; };
 		E8A9143C279B2D3800095A98 /* AsyncNetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A9143B279B2D3800095A98 /* AsyncNetworkServiceTests.swift */; };
@@ -52,6 +53,7 @@
 
 /* Begin PBXFileReference section */
 		4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResponseInterceptor.swift; sourceTree = "<group>"; };
+		4AB0D50628763C0E00C36A3A /* AuthenticationTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenProvider.swift; sourceTree = "<group>"; };
 		8347924927FCBCC100AFDDF3 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncNetworkService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8A9142F279B2D3800095A98 /* AsyncNetworkService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncNetworkService.h; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				E8A91458279B353200095A98 /* URLRequestBuilder.swift */,
 				E8A9147E279B677600095A98 /* NetworkLogger.swift */,
 				4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */,
+				4AB0D50628763C0E00C36A3A /* AuthenticationTokenProvider.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -388,6 +391,7 @@
 				E8A91447279B2F5F00095A98 /* AsyncHTTPNetworkService.swift in Sources */,
 				E8A9144C279B308900095A98 /* URLRequest+.swift in Sources */,
 				E8A91457279B33F500095A98 /* NotificationObserver.swift in Sources */,
+				4AB0D50728763C0E00C36A3A /* AuthenticationTokenProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AsyncNetworkService/Common/AuthenticationTokenProvider.swift
+++ b/AsyncNetworkService/Common/AuthenticationTokenProvider.swift
@@ -1,0 +1,12 @@
+//
+//  AuthenticationTokenProvider.swift
+//  AsyncNetworkService
+//
+//  Created by Alex Maslov on 2022-07-06.
+//
+
+import Foundation
+
+public protocol AuthenticationTokenProvider: AnyObject {
+    var authenticationToken: String { get }
+}

--- a/AsyncNetworkService/Common/NotificationObserver.swift
+++ b/AsyncNetworkService/Common/NotificationObserver.swift
@@ -47,12 +47,3 @@ func postNotification<T>(notification: AsyncNotification<T>, value: T) {
     let userInfo = ["value": UserInfoContainer(value)]
     NotificationCenter.default.post(name: notification.notificationName, object: nil, userInfo: userInfo)
 }
-
-protocol BearerTokenAware {
-    var authenticationToken: String { get set }
-}
-
-// MARK: - Refresh Token Notification
-
-/// A AsyncNotification type that is used to notify services of when a token has refreshed.
-let refreshTokenNotification: AsyncNotification<String> = AsyncNotification()


### PR DESCRIPTION
The idea here is that instead of having to provide a token or use notifications we can just provide a token provider so that we dont have to worry about updating the network service with latest tokens. It will be able to pull the latest token from the source whenever it needs.

```swift
class TokenStorer: AuthenticationTokenProvider {
    var authenticationToken {
        store.accessToken
    }
}
```