### PR TITLE
Remove token provider

### DIFF
--- a/AsyncNetworkService/AsyncHTTPNetworkService.swift
+++ b/AsyncNetworkService/AsyncHTTPNetworkService.swift
@@ -9,8 +9,6 @@ import Foundation
 
 /// A  protocol used for `AsyncHTTPNetworkService` that speaks to a remote resource via URL requests
 public protocol AsyncNetworkService: AnyObject {
-    var authenticationTokenProvider: AuthenticationTokenProvider? { get set }
-
     /// If this is set, all network requests made through this service will have the modifier applied.
     /// To apply multiple mutations to each network request, use `CompositeNetworkRequestModifier`.
     var requestModifiers: [NetworkRequestModifier] { get set }
@@ -46,15 +44,8 @@ public class AsyncHTTPNetworkService: AsyncNetworkService {
     }
 
     private func applyModifiers(to request: ConvertsToURLRequest) -> URLRequest {
-        let updatedRequest = requestModifiers.reduce(request.asURLRequest()) { previousRequest, modifier in
+        requestModifiers.reduce(request.asURLRequest()) { previousRequest, modifier in
             modifier.mutate(previousRequest)
-        }
-        // if we've set the authorization header lets update it with the new one that got sent back from the client
-        // if not, return the regular request
-        if updatedRequest.allHTTPHeaderFields?["Authorization"] != nil {
-            return updatedRequest.token(authenticationTokenProvider?.authenticationToken ?? "") // for all calls, for simplicity - lets add the bearer token
-        } else {
-            return updatedRequest
         }
     }
 


### PR DESCRIPTION
Since we need a `BearerTokenRequestModifier` anyway to establish the Authorization header it feels redundant to have the `AsyncHTTPNetworkService` modify the header as well. The problem currently with just not using the token provider is that the  `AsyncHTTPNetworkService` override the `Authorization` with an empty string, even though the `BearerTokenRequestModifier` did its job already.